### PR TITLE
Changed EventHandler of AsyncPlayerChatEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 <!--            <url>http://repo.bukkit.org/content/groups/public/</url> -->
            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
        </repository>
+       
    </repositories>
    <dependencies>
        <dependency>
@@ -40,8 +41,9 @@
            <scope>provided</scope>
        </dependency>
    </dependencies>
+   
    <properties>
-   	<version>1.3</version>
+   	<version>1.3.1</version>
    	<package>net.kaikk.mc.krules</package>
    	<name>KRules</name>
    </properties>

--- a/src/main/java/net/kaikk/mc/krules/EventListener.java
+++ b/src/main/java/net/kaikk/mc/krules/EventListener.java
@@ -3,6 +3,7 @@ package net.kaikk.mc.krules;
 import java.util.regex.Matcher;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -65,10 +66,13 @@ class EventListener implements Listener {
 		}
 	}
 
-	@EventHandler(ignoreCancelled=true)
+	@EventHandler(priority=EventPriority.LOWEST)
 	void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
 		if (!instance.ds.hasPlayerAgreedWithRules(event.getPlayer().getUniqueId(), true)) {
 			event.getPlayer().sendMessage(instance.config.acceptRules);
+			event.setMessage(""); 
+			
+			
 			event.setCancelled(true);
 		}
 	}

--- a/src/main/java/net/kaikk/mc/krules/EventListener.java
+++ b/src/main/java/net/kaikk/mc/krules/EventListener.java
@@ -66,7 +66,7 @@ class EventListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST)
+	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
 	void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
 		if (!instance.ds.hasPlayerAgreedWithRules(event.getPlayer().getUniqueId(), true)) {
 			event.getPlayer().sendMessage(instance.config.acceptRules);


### PR DESCRIPTION
Changed Event Handler of AsyncPlayerChat to include a priority: EventPriority.LOWEST so that it
can interact with MineverseChat. updated Version in pom.yml to 1.3.1